### PR TITLE
the query depends on the user if the user provides a different  form of query params data for example, I want an APPROVED user but I passed the approved one extra db call will be fired for that data but nothing will be found  #31

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,8 @@ require('dotenv').config()
 const mongoose = require('mongoose')
 const express = require('express')
 const cors = require('cors')
-const helmet = require('helmet') // Add additional security headers to request 
-const logger = require('morgan')
+const helmet = require('helmet') // Add additional security headers to request
+// const logger = require('morgan')
 const User = require('./models/user.model')
 const app = express()
 const bcrypt = require('bcrypt')
@@ -46,7 +46,7 @@ async function initialise () {
       password: bcrypt.hashSync(process.env.ADMIN_PASSWORD, 10),
       userStatus: constants.userStatus.approved
     })
-    // console.log(user)
+    console.log(user)
     console.log('Welcome System Administrator!')
   } catch (err) {
     console.log('Error creating user!', err.message)
@@ -78,6 +78,6 @@ app.get('/', (req, res) => {
 })
 
 require('./routes/auth.routes')(app)
-require('./routes/ticket.routes')(app)
 app.use(limiter)
+require('./routes/ticket.routes')(app)
 require('./routes/user.routes')(app)

--- a/controllers/ticket.controller.js
+++ b/controllers/ticket.controller.js
@@ -131,10 +131,15 @@ exports.getAllTickets = async (req, res) => {
      *  - CUSTOMER : should get all the tickets created by him/her
      *  - ENGINEER : should get all the tickets assigned to him/her
      */
-  const queryObj = {}
-  // if status is not provided in query params by default we show the approved user
-  queryObj.status = req.query.status || constants.userStatus.approved
+  const queryObj = {
+    status: { $eq: '' },
+    reporter: { $eq: '' },
+    assignee: { $eq: '' }
 
+  }
+  // if status is not provided in query params by default we show the approved user
+  queryObj.status.$eq = req.query.status || constants.userStatus.approved
+  console.log(queryObj)
   // if (req.query.status != undefined) {
   //   queryObj.status = req.query.status
   // }
@@ -144,16 +149,16 @@ exports.getAllTickets = async (req, res) => {
   if (savedUser.userType == constants.userTypes.admin) {
     // Do anything
   } else if (savedUser.userType == constants.userTypes.customer) {
-    queryObj.reporter = savedUser.userId
+    queryObj.reporter.$eq = savedUser.userId
   } else {
-    queryObj.assignee = savedUser.userId
+    queryObj.assignee.$eq = savedUser.userId
   }
 
   const tickets = await Ticket.find(queryObj)
   if (tickets.length == 0) {
-    console.log(`tickets is ${queryObj.status}, check with status`)
+    console.log(`tickets is ${queryObj.status.$eq}, check with status`)
     return res.status(401).send({
-      message: `There is NO tickets with this status [${queryObj.status}]`
+      message: `There is NO tickets with this status [${queryObj.status.$eq}]`
     })
   }
   res.status(200).send(objectConverter.ticketListResponse(tickets))


### PR DESCRIPTION
Most database connector libraries offer a way of safely embedding untrusted data into a query by means of query parameters or prepared statements.

For NoSQL queries, make use of an operator like MongoDB's $eq to ensure that untrusted data is interpreted as a literal value and not as a query object. Alternatively, check that the untrusted data is a literal value and not a query object before using it in a query.