### PR TITLE
fix(ticket): scope getOneTicket by role to prevent IDOR

### DIFF
--- a/src/controllers/ticket.controller.js
+++ b/src/controllers/ticket.controller.js
@@ -327,9 +327,31 @@ export const getAllTickets = async (req, res) => {
 
 /**
  * * This controller fetch ticket by id
+ *
+ * Authorization mirrors getAllTickets:
+ *   - ADMIN    : may read any ticket
+ *   - CUSTOMER : may read only tickets they reported
+ *   - ENGINEER : may read only tickets assigned to them
+ *
+ * Without this scope, any authenticated user could read any other user's
+ * private support ticket (which may contain account details, error logs,
+ * or internal discussion) by scanning ticket ids — an IDOR.
  */
 export const getOneTicket = async (req, res) => {
     try {
+        const loggedInUser = await User.findOne({
+            userId: { $eq: req.decoded.userId },
+        });
+        if (!loggedInUser) {
+            console.log("No user in DB !!!");
+            return res.status(403).json({
+                data: "",
+                message: "No user in DB !!!",
+                statusCode: 403,
+                success: false,
+            });
+        }
+
         const ticket = await Ticket.findOne({
             _id: req.query.id,
         });
@@ -342,7 +364,24 @@ export const getOneTicket = async (req, res) => {
                 success: false,
             });
         }
-        
+
+        // Role-based scope, matching getAllTickets.
+        if (loggedInUser.userType !== userTypes.admin) {
+            const isReporter =
+                ticket.reporter && ticket.reporter === loggedInUser.userId;
+            const isAssignee =
+                ticket.assignee && ticket.assignee === loggedInUser.userId;
+            if (!isReporter && !isAssignee) {
+                console.log(`Unauthorized ticket access by userId -> [${loggedInUser.userId}]`);
+                return res.status(403).json({
+                    data: "",
+                    message: "Unauthorized Access !",
+                    statusCode: 403,
+                    success: false,
+                });
+            }
+        }
+
         console.log(`Ticket fetched successfully`);
 
         res.status(200).json({


### PR DESCRIPTION
## Summary

`GET /tickets/get-ticket?id=...` (`getOneTicket`) required only `verifyToken` and performed no role or ownership check. Any logged-in user could read any ticket by id — including **other customers' private support tickets**, which may contain account details, error logs, or internal discussion.

This is an Insecure Direct Object Reference (IDOR).

## Impact

Compare with `getAllTickets` in the same file, which already implements proper role-based scoping:
- **ADMIN** → all tickets
- **CUSTOMER** → tickets they reported
- **ENGINEER** → tickets assigned to them

`getOneTicket` had none of this. A customer scanning `?id=` values could read any ticket in the system.

## Reproduce

1. Sign in as customer A; create a ticket; note its `_id`.
2. Sign in as customer B (different account).
3. As B, `GET /tickets/get-ticket?id=<A_ticket_id>` with B's token.
4. Observe A's full ticket returned (200), including description and any internal status/assignee fields.

## Fix

Apply the same role-based scope already used by `getAllTickets`:
- ADMIN may read any ticket.
- Everyone else must be the ticket's `reporter` or `assignee`; otherwise 403.

## Notes

- Pattern mirrors the existing `getAllTickets` logic — no new conventions.
- No test suite; validated with `node --check`.